### PR TITLE
feat(security): Add key security improvements to the Terraform provider

### DIFF
--- a/litellm/data_source_credential.go
+++ b/litellm/data_source_credential.go
@@ -55,7 +55,7 @@ func dataSourceLiteLLMCredentialRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	var credentialResp CredentialResponse
-	err = handleCredentialAPIResponse(resp, &credentialResp)
+	err = handleCredentialAPIResponse(resp, &credentialResp, client)
 	if err != nil {
 		if err.Error() == "credential_not_found" {
 			return fmt.Errorf("credential '%s' not found", credentialName)

--- a/litellm/data_source_vector_store.go
+++ b/litellm/data_source_vector_store.go
@@ -83,7 +83,7 @@ func dataSourceLiteLLMVectorStoreRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	var vectorStoreResp VectorStoreResponse
-	err = handleVectorStoreAPIResponse(resp, &vectorStoreResp)
+	err = handleVectorStoreAPIResponse(resp, &vectorStoreResp, client)
 	if err != nil {
 		if err.Error() == "vector_store_not_found" {
 			return fmt.Errorf("vector store '%s' not found", vectorStoreID)

--- a/litellm/provider.go
+++ b/litellm/provider.go
@@ -39,6 +39,13 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("LITELLM_API_KEY", nil),
 				Description: "The API key for authenticating with LiteLLM",
 			},
+			"insecure_skip_verify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				DefaultFunc: schema.EnvDefaultFunc("LITELLM_INSECURE_SKIP_VERIFY", false),
+				Description: "Skip TLS certificate verification. Only use for development or when using self-signed certificates",
+			},
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -47,9 +54,10 @@ func Provider() *schema.Provider {
 // providerConfigure configures the provider with the given schema data.
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := ProviderConfig{
-		APIBase: d.Get("api_base").(string),
-		APIKey:  d.Get("api_key").(string),
+		APIBase:            d.Get("api_base").(string),
+		APIKey:             d.Get("api_key").(string),
+		InsecureSkipVerify: d.Get("insecure_skip_verify").(bool),
 	}
 
-	return NewClient(config.APIBase, config.APIKey), nil
+	return NewClient(config.APIBase, config.APIKey, config.InsecureSkipVerify), nil
 }

--- a/litellm/provider_test.go
+++ b/litellm/provider_test.go
@@ -48,7 +48,7 @@ func createTestUsers(t *testing.T) {
 		return
 	}
 
-	client := NewClient(apiBase, apiKey)
+	client := NewClient(apiBase, apiKey, false)
 
 	// Create test users
 	users := []map[string]interface{}{

--- a/litellm/resource_credential_crud.go
+++ b/litellm/resource_credential_crud.go
@@ -40,7 +40,7 @@ func resourceLiteLLMCredentialCreate(d *schema.ResourceData, m interface{}) erro
 	}
 	defer resp.Body.Close()
 
-	err = handleCredentialAPIResponse(resp, nil)
+	err = handleCredentialAPIResponse(resp, nil, client)
 	if err != nil {
 		return fmt.Errorf("failed to create credential: %w", err)
 	}
@@ -74,7 +74,7 @@ func resourceLiteLLMCredentialRead(d *schema.ResourceData, m interface{}) error 
 	}
 
 	var credentialResp CredentialResponse
-	err = handleCredentialAPIResponse(resp, &credentialResp)
+	err = handleCredentialAPIResponse(resp, &credentialResp, client)
 	if err != nil {
 		if err.Error() == "credential_not_found" {
 			d.SetId("")
@@ -123,7 +123,7 @@ func resourceLiteLLMCredentialUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 	defer resp.Body.Close()
 
-	err = handleCredentialAPIResponse(resp, nil)
+	err = handleCredentialAPIResponse(resp, nil, client)
 	if err != nil {
 		return fmt.Errorf("failed to update credential: %w", err)
 	}
@@ -142,7 +142,7 @@ func resourceLiteLLMCredentialDelete(d *schema.ResourceData, m interface{}) erro
 	}
 	defer resp.Body.Close()
 
-	err = handleCredentialAPIResponse(resp, nil)
+	err = handleCredentialAPIResponse(resp, nil, client)
 	if err != nil {
 		if err.Error() == "credential_not_found" {
 			d.SetId("")

--- a/litellm/resource_mcp_server_crud.go
+++ b/litellm/resource_mcp_server_crud.go
@@ -183,7 +183,7 @@ func resourceLiteLLMMCPServerCreate(d *schema.ResourceData, m interface{}) error
 	defer resp.Body.Close()
 
 	var mcpResp MCPServerResponse
-	if err := handleMCPAPIResponse(resp, &mcpResp); err != nil {
+	if err := handleMCPAPIResponse(resp, &mcpResp, client); err != nil {
 		return fmt.Errorf("failed to create MCP server: %w", err)
 	}
 
@@ -214,7 +214,7 @@ func resourceLiteLLMMCPServerRead(d *schema.ResourceData, m interface{}) error {
 	defer resp.Body.Close()
 
 	var mcpResp MCPServerResponse
-	if err := handleMCPAPIResponse(resp, &mcpResp); err != nil {
+	if err := handleMCPAPIResponse(resp, &mcpResp, client); err != nil {
 		if err.Error() == "mcp_server_not_found" {
 			d.SetId("")
 			return nil
@@ -246,7 +246,7 @@ func resourceLiteLLMMCPServerUpdate(d *schema.ResourceData, m interface{}) error
 	defer resp.Body.Close()
 
 	var mcpResp MCPServerResponse
-	if err := handleMCPAPIResponse(resp, &mcpResp); err != nil {
+	if err := handleMCPAPIResponse(resp, &mcpResp, client); err != nil {
 		return fmt.Errorf("failed to update MCP server: %w", err)
 	}
 

--- a/litellm/resource_model.go
+++ b/litellm/resource_model.go
@@ -153,8 +153,9 @@ func resourceLiteLLMModel() *schema.Resource {
 				Sensitive: true,
 			},
 			"vertex_credentials": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 			"additional_litellm_params": {
 				Type:     schema.TypeMap,

--- a/litellm/resource_model_crud.go
+++ b/litellm/resource_model_crud.go
@@ -252,7 +252,7 @@ func createOrUpdateModel(d *schema.ResourceData, m interface{}, isUpdate bool) e
 	}
 	defer resp.Body.Close()
 
-	_, err = handleAPIResponse(resp, modelReq)
+	_, err = handleAPIResponse(resp, modelReq, client)
 	if err != nil {
 		if isUpdate && err.Error() == "model_not_found" {
 			return createOrUpdateModel(d, m, false)
@@ -283,7 +283,7 @@ func resourceLiteLLMModelRead(d *schema.ResourceData, m interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	modelResp, err := handleAPIResponse(resp, nil)
+	modelResp, err := handleAPIResponse(resp, nil, client)
 	if err != nil {
 		if err.Error() == "model_not_found" {
 			d.SetId("")
@@ -383,7 +383,7 @@ func resourceLiteLLMModelDelete(d *schema.ResourceData, m interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	_, err = handleAPIResponse(resp, deleteReq)
+	_, err = handleAPIResponse(resp, deleteReq, client)
 	if err != nil {
 		if err.Error() == "model_not_found" {
 			d.SetId("")

--- a/litellm/resource_vector_store_crud.go
+++ b/litellm/resource_vector_store_crud.go
@@ -44,7 +44,7 @@ func resourceLiteLLMVectorStoreCreate(d *schema.ResourceData, m interface{}) err
 	}
 	defer resp.Body.Close()
 
-	err = handleVectorStoreAPIResponse(resp, nil)
+	err = handleVectorStoreAPIResponse(resp, nil, client)
 	if err != nil {
 		return fmt.Errorf("failed to create vector store: %w", err)
 	}
@@ -77,7 +77,7 @@ func resourceLiteLLMVectorStoreRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	var vectorStoreResp VectorStoreResponse
-	err = handleVectorStoreAPIResponse(resp, &vectorStoreResp)
+	err = handleVectorStoreAPIResponse(resp, &vectorStoreResp, client)
 	if err != nil {
 		if err.Error() == "vector_store_not_found" {
 			d.SetId("")
@@ -133,7 +133,7 @@ func resourceLiteLLMVectorStoreUpdate(d *schema.ResourceData, m interface{}) err
 	}
 	defer resp.Body.Close()
 
-	err = handleVectorStoreAPIResponse(resp, nil)
+	err = handleVectorStoreAPIResponse(resp, nil, client)
 	if err != nil {
 		return fmt.Errorf("failed to update vector store: %w", err)
 	}
@@ -155,7 +155,7 @@ func resourceLiteLLMVectorStoreDelete(d *schema.ResourceData, m interface{}) err
 	}
 	defer resp.Body.Close()
 
-	err = handleVectorStoreAPIResponse(resp, nil)
+	err = handleVectorStoreAPIResponse(resp, nil, client)
 	if err != nil {
 		if err.Error() == "vector_store_not_found" {
 			d.SetId("")

--- a/litellm/types.go
+++ b/litellm/types.go
@@ -2,8 +2,9 @@ package litellm
 
 // ProviderConfig holds the configuration for the LiteLLM provider.
 type ProviderConfig struct {
-	APIBase string
-	APIKey  string
+	APIBase            string
+	APIKey             string
+	InsecureSkipVerify bool
 }
 
 // ErrorResponse represents an error response from the API.

--- a/litellm/utils.go
+++ b/litellm/utils.go
@@ -34,7 +34,7 @@ func isModelNotFoundError(errResp ErrorResponse) bool {
 	return false
 }
 
-func handleAPIResponse(resp *http.Response, reqBody interface{}) (*ModelResponse, error) {
+func handleAPIResponse(resp *http.Response, reqBody interface{}, client *Client) (*ModelResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %v", err)
@@ -49,7 +49,7 @@ func handleAPIResponse(resp *http.Response, reqBody interface{}) (*ModelResponse
 		}
 		reqBodyBytes, _ := json.Marshal(reqBody)
 		return nil, fmt.Errorf("API request failed: Status: %s, Response: %s, Request: %s",
-			resp.Status, string(bodyBytes), string(reqBodyBytes))
+			resp.Status, client.redactSensitiveData(string(bodyBytes)), client.redactSensitiveData(string(reqBodyBytes)))
 	}
 
 	var modelResp ModelResponse
@@ -112,7 +112,7 @@ func GetBoolValue(apiValue, defaultValue bool) bool {
 }
 
 // handleMCPAPIResponse handles API responses specifically for MCP server operations
-func handleMCPAPIResponse(resp *http.Response, result interface{}) error {
+func handleMCPAPIResponse(resp *http.Response, result interface{}, client *Client) error {
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %v", err)
@@ -126,7 +126,7 @@ func handleMCPAPIResponse(resp *http.Response, result interface{}) error {
 			}
 		}
 		return fmt.Errorf("API request failed: Status: %s, Response: %s",
-			resp.Status, string(bodyBytes))
+			resp.Status, client.redactSensitiveData(string(bodyBytes)))
 	}
 
 	if err := json.Unmarshal(bodyBytes, result); err != nil {
@@ -189,7 +189,7 @@ func isCredentialNotFoundError(errResp ErrorResponse) bool {
 }
 
 // handleCredentialAPIResponse handles API responses specifically for credential operations
-func handleCredentialAPIResponse(resp *http.Response, result interface{}) error {
+func handleCredentialAPIResponse(resp *http.Response, result interface{}, client *Client) error {
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %v", err)
@@ -207,7 +207,7 @@ func handleCredentialAPIResponse(resp *http.Response, result interface{}) error 
 			}
 		}
 		return fmt.Errorf("API request failed: Status: %s, Response: %s",
-			resp.Status, string(bodyBytes))
+			resp.Status, client.redactSensitiveData(string(bodyBytes)))
 	}
 
 	// For credential operations, we might get a simple string response or a credential object
@@ -248,7 +248,7 @@ func isVectorStoreNotFoundError(errResp ErrorResponse) bool {
 }
 
 // handleVectorStoreAPIResponse handles API responses specifically for vector store operations
-func handleVectorStoreAPIResponse(resp *http.Response, result interface{}) error {
+func handleVectorStoreAPIResponse(resp *http.Response, result interface{}, client *Client) error {
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %v", err)
@@ -266,7 +266,7 @@ func handleVectorStoreAPIResponse(resp *http.Response, result interface{}) error
 			}
 		}
 		return fmt.Errorf("API request failed: Status: %s, Response: %s",
-			resp.Status, string(bodyBytes))
+			resp.Status, client.redactSensitiveData(string(bodyBytes)))
 	}
 
 	if result != nil {


### PR DESCRIPTION
## Summary

This PR ports security improvements to add security features:

- **TLS verification enabled by default** - Previously hardcoded to `InsecureSkipVerify: true`, now defaults to secure TLS verification with an optional `insecure_skip_verify` provider setting for development environments
- **Sensitive data redaction in logs** - Added `redactSensitiveData()` method that masks API keys, tokens, passwords, secrets, credentials, and other sensitive fields in log output
- **UUID validation for Team IDs** - Added `validateUUID()` method to prevent injection attacks via malformed team IDs
- **Updated all API response handlers** to use sensitive data redaction in error messages
- **Fixed missing `Sensitive: true`** on `vertex_credentials` field to prevent Google Cloud credentials from being exposed in terraform plan/apply output

## Security Features

| Feature | Before | After |
|---------|--------|-------|
| TLS Verification | Disabled (insecure) | Enabled by default (secure) |
| Log Redaction | None (credentials exposed) | Sensitive fields masked as `[REDACTED]` |
| UUID Validation | None | Team IDs validated before API calls |
| `vertex_credentials` | Not marked sensitive | Marked as `Sensitive: true` |

## Files Changed

- `litellm/client.go` - Added `InsecureSkipVerify` field, `validateUUID()`, `redactSensitiveData()` methods
- `litellm/provider.go` - Added `insecure_skip_verify` schema option
- `litellm/types.go` - Added `InsecureSkipVerify` to ProviderConfig
- `litellm/utils.go` - Updated API response handlers to use redaction
- `litellm/resource_model.go` - Added `Sensitive: true` to `vertex_credentials`
- Various CRUD files - Updated to pass client parameter for redaction

## Test plan

- [x] `go build` compiles successfully
- [x] `go vet` passes with no issues