### PR TITLE
docs: update key resource docs for v0.2.0 write-only attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,38 +63,42 @@ Here's an example of creating an API key. The `key` value is **write-only** — 
 
 ```hcl
 resource "litellm_key" "example_key" {
-  key_alias             = "prod-key-1"
-  models                = ["gpt-4", "claude-3.5-sonnet"]
-  max_budget            = 100.0
-  user_id               = "user123"
-  team_id               = "team456"
+  models               = ["gpt-4", "claude-3.5-sonnet"]
+  max_budget           = 100.0
+  user_id              = "user123"
+  team_id              = "team456"
   max_parallel_requests = 5
-  tpm_limit             = 1000
-  rpm_limit             = 60
-  budget_duration       = "monthly"
+  tpm_limit            = 1000
+  rpm_limit            = 60
+  budget_duration      = "monthly"
+  key_alias            = "prod-key-1"
+  duration             = "30d"
+  metadata             = {
+    environment = "production"
+  }
   allowed_cache_controls = ["no-cache", "max-age=3600"]
-  soft_budget            = 80.0
-  aliases                = {
+  soft_budget          = 80.0
+  aliases              = {
     "gpt-4" = "gpt4"
   }
-  config                 = {
+  config               = {
     default_model = "gpt-4"
   }
-  permissions            = {
+  permissions          = {
     can_create_keys = "true"
   }
-  model_max_budget       = {
+  model_max_budget     = {
     "gpt-4" = 50.0
   }
-  model_rpm_limit        = {
+  model_rpm_limit      = {
     "claude-3.5-sonnet" = 30
   }
-  model_tpm_limit        = {
+  model_tpm_limit      = {
     "gpt-4" = 500
   }
-  guardrails             = ["content_filter", "token_limit"]
-  blocked                = false
-  tags                   = ["production", "api"]
+  guardrails           = ["content_filter", "token_limit"]
+  blocked              = false
+  tags                 = ["production", "api"]
 }
 
 # Capture the key during apply — it won't be available afterward

--- a/README.md
+++ b/README.md
@@ -73,28 +73,28 @@ resource "litellm_key" "example_key" {
   rpm_limit             = 60
   budget_duration       = "monthly"
   allowed_cache_controls = ["no-cache", "max-age=3600"]
-  soft_budget           = 80.0
-  aliases = {
+  soft_budget            = 80.0
+  aliases                = {
     "gpt-4" = "gpt4"
   }
-  config = {
+  config                 = {
     default_model = "gpt-4"
   }
-  permissions = {
+  permissions            = {
     can_create_keys = "true"
   }
-  model_max_budget = {
+  model_max_budget       = {
     "gpt-4" = 50.0
   }
-  model_rpm_limit = {
+  model_rpm_limit        = {
     "claude-3.5-sonnet" = 30
   }
-  model_tpm_limit = {
+  model_tpm_limit        = {
     "gpt-4" = 500
   }
-  guardrails = ["content_filter", "token_limit"]
-  blocked    = false
-  tags       = ["production", "api"]
+  guardrails             = ["content_filter", "token_limit"]
+  blocked                = false
+  tags                   = ["production", "api"]
 }
 
 # Capture the key during apply — it won't be available afterward

--- a/README.md
+++ b/README.md
@@ -72,7 +72,29 @@ resource "litellm_key" "example_key" {
   tpm_limit             = 1000
   rpm_limit             = 60
   budget_duration       = "monthly"
-  tags                  = ["production", "api"]
+  allowed_cache_controls = ["no-cache", "max-age=3600"]
+  soft_budget           = 80.0
+  aliases = {
+    "gpt-4" = "gpt4"
+  }
+  config = {
+    default_model = "gpt-4"
+  }
+  permissions = {
+    can_create_keys = "true"
+  }
+  model_max_budget = {
+    "gpt-4" = 50.0
+  }
+  model_rpm_limit = {
+    "claude-3.5-sonnet" = 30
+  }
+  model_tpm_limit = {
+    "gpt-4" = 500
+  }
+  guardrails = ["content_filter", "token_limit"]
+  blocked    = false
+  tags       = ["production", "api"]
 }
 
 # Capture the key during apply — it won't be available afterward

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Terraform provider allows you to manage LiteLLM resources through Infrastru
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.11 (required for write-only attribute support in `litellm_key`)
 - [Go](https://golang.org/doc/install) >= 1.16 (for development)
 
 ## Using the Provider
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     litellm = {
       source  = "BerriAI/litellm"
-      version = "~> 0.1.1" #HERE UPDATE VERSION ACCORDINGLY
+      version = "~> 0.2.0"
     }
   }
 }
@@ -59,46 +59,27 @@ resource "litellm_model" "gpt4" {
 
 For full details on the <code>litellm_model</code> resource, see the [model resource documentation](docs/resources/model.md).
 
-Here's an example of creating an API key with various options:
+Here's an example of creating an API key. The `key` value is **write-only** — available during `terraform apply` but never stored in state. Pipe it directly to a secrets manager:
 
 ```hcl
 resource "litellm_key" "example_key" {
-  models               = ["gpt-4", "claude-3.5-sonnet"]
-  max_budget           = 100.0
-  user_id              = "user123"
-  team_id              = "team456"
+  key_alias             = "prod-key-1"
+  models                = ["gpt-4", "claude-3.5-sonnet"]
+  max_budget            = 100.0
+  user_id               = "user123"
+  team_id               = "team456"
   max_parallel_requests = 5
-  tpm_limit            = 1000
-  rpm_limit            = 60
-  budget_duration      = "monthly"
-  key_alias            = "prod-key-1"
-  duration             = "30d"
-  metadata             = {
-    environment = "production"
-  }
-  allowed_cache_controls = ["no-cache", "max-age=3600"]
-  soft_budget          = 80.0
-  aliases              = {
-    "gpt-4" = "gpt4"
-  }
-  config               = {
-    default_model = "gpt-4"
-  }
-  permissions          = {
-    can_create_keys = "true"
-  }
-  model_max_budget     = {
-    "gpt-4" = 50.0
-  }
-  model_rpm_limit      = {
-    "claude-3.5-sonnet" = 30
-  }
-  model_tpm_limit      = {
-    "gpt-4" = 500
-  }
-  guardrails           = ["content_filter", "token_limit"]
-  blocked              = false
-  tags                 = ["production", "api"]
+  tpm_limit             = 1000
+  rpm_limit             = 60
+  budget_duration       = "monthly"
+  tags                  = ["production", "api"]
+}
+
+# Capture the key during apply — it won't be available afterward
+resource "aws_ssm_parameter" "litellm_key" {
+  name  = "/myapp/litellm-key"
+  type  = "SecureString"
+  value = litellm_key.example_key.key
 }
 ```
 

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -6,25 +6,47 @@ Manages a LiteLLM API key.
 
 ## Example Usage
 
-### Basic key
-
 ```hcl
 resource "litellm_key" "example" {
-  key_alias = "prod-key-1"
-  models    = ["gpt-4", "claude-3.5-sonnet"]
+  models               = ["gpt-3.5-turbo", "gpt-4"]
+  max_budget           = 100.0
+  user_id              = "user123"
+  team_id              = "team456"
+  max_parallel_requests = 5
+  metadata             = {
+    "environment" = "production"
+  }
+  tpm_limit            = 1000
+  rpm_limit            = 60
+  budget_duration      = "monthly"
+  allowed_cache_controls = ["no-cache", "max-age=3600"]
+  soft_budget          = 80.0
+  key_alias            = "prod-key-1"
+  duration             = "30d"
+  aliases              = {
+    "gpt-3.5-turbo" = "chatgpt"
+  }
+  config               = {
+    "default_model" = "gpt-3.5-turbo"
+  }
+  permissions          = {
+    "can_create_keys" = "true"
+  }
+  model_max_budget     = {
+    "gpt-4" = 50.0
+  }
+  model_rpm_limit      = {
+    "gpt-3.5-turbo" = 30
+  }
+  model_tpm_limit      = {
+    "gpt-4" = 500
+  }
+  guardrails           = ["content_filter", "token_limit"]
+  blocked              = false
+  tags                 = ["production", "api"]
 }
-```
 
-### Pipe key to AWS SSM during apply
-
-Since the `key` value is write-only, it is only available during the initial `terraform apply`. Use it immediately to store it in a secrets manager:
-
-```hcl
-resource "litellm_key" "example" {
-  key_alias = "prod-key-1"
-  models    = ["gpt-4", "claude-3.5-sonnet"]
-}
-
+# Capture the key during apply — it won't be available afterward
 resource "aws_ssm_parameter" "litellm_key" {
   name  = "/myapp/litellm-key"
   type  = "SecureString"
@@ -32,96 +54,53 @@ resource "aws_ssm_parameter" "litellm_key" {
 }
 ```
 
-### Full example
-
-```hcl
-resource "litellm_key" "example" {
-  models                = ["gpt-3.5-turbo", "gpt-4"]
-  max_budget            = 100.0
-  user_id               = "user123"
-  team_id               = "team456"
-  max_parallel_requests = 5
-  metadata = {
-    "environment" = "production"
-  }
-  tpm_limit              = 1000
-  rpm_limit              = 60
-  budget_duration        = "monthly"
-  allowed_cache_controls = ["no-cache", "max-age=3600"]
-  soft_budget            = 80.0
-  key_alias              = "prod-key-1"
-  duration               = "30d"
-  aliases = {
-    "gpt-3.5-turbo" = "chatgpt"
-  }
-  config = {
-    "default_model" = "gpt-3.5-turbo"
-  }
-  permissions = {
-    "can_create_keys" = "true"
-  }
-  model_max_budget = {
-    "gpt-4" = 50.0
-  }
-  model_rpm_limit = {
-    "gpt-3.5-turbo" = 30
-  }
-  model_tpm_limit = {
-    "gpt-4" = 500
-  }
-  guardrails = ["content_filter", "token_limit"]
-  blocked    = false
-  tags       = ["production", "api"]
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:
 
-* `models` - (Optional) List of models that can be used with this key.
+* `models` - (Optional) List of models that can be used with this key. This restricts the key to only use the specified models.
 
-* `max_budget` - (Optional) Maximum budget for this key.
+* `max_budget` - (Optional) Maximum budget for this key. This sets an upper limit on the total spend allowed for this key.
 
-* `user_id` - (Optional) User ID associated with this key.
+* `user_id` - (Optional) User ID associated with this key. This links the key to a specific user in the LiteLLM system.
 
-* `team_id` - (Optional) Team ID associated with this key.
+* `team_id` - (Optional) Team ID associated with this key. This links the key to a specific team in the LiteLLM system.
 
-* `max_parallel_requests` - (Optional) Maximum number of parallel requests allowed for this key.
+* `max_parallel_requests` - (Optional) Maximum number of parallel requests allowed for this key. This helps in controlling concurrent usage.
 
-* `metadata` - (Optional) Metadata associated with this key.
+* `metadata` - (Optional) Metadata associated with this key. This can be used to store additional, custom information about the key.
 
-* `tpm_limit` - (Optional) Tokens per minute limit for this key.
+* `tpm_limit` - (Optional) Tokens per minute limit for this key. This sets a rate limit based on the number of tokens processed.
 
-* `rpm_limit` - (Optional) Requests per minute limit for this key.
+* `rpm_limit` - (Optional) Requests per minute limit for this key. This sets a rate limit based on the number of API calls.
 
-* `budget_duration` - (Optional) Duration for the budget (e.g., `"monthly"`, `"weekly"`).
+* `budget_duration` - (Optional) Duration for the budget (e.g., "monthly", "weekly"). This defines the time period for which the `max_budget` applies.
 
-* `allowed_cache_controls` - (Optional) List of allowed cache control directives.
+* `allowed_cache_controls` - (Optional) List of allowed cache control directives. This can be used to control caching behavior for requests made with this key.
 
-* `soft_budget` - (Optional) Soft budget limit for this key.
+* `soft_budget` - (Optional) Soft budget limit for this key. This can be used to set a warning threshold before reaching the `max_budget`.
 
-* `key_alias` - (Optional) Alias for this key.
+* `key_alias` - (Optional) Alias for this key. This provides a human-readable identifier for the key.
 
-* `duration` - (Optional) Duration for which this key is valid (e.g., `"30d"`).
+* `duration` - (Optional) Duration for which this key is valid. This sets an expiration time for the key.
 
-* `aliases` - (Optional) Map of model aliases.
+* `aliases` - (Optional) Map of model aliases. This allows you to create custom names for models when using this key.
 
-* `config` - (Optional) Configuration options for this key.
+* `config` - (Optional) Configuration options for this key. This can be used to set key-specific settings.
 
-* `permissions` - (Optional) Permissions associated with this key.
+* `permissions` - (Optional) Permissions associated with this key. This defines what actions are allowed with this key.
 
-* `model_max_budget` - (Optional) Maximum budget per model.
+* `model_max_budget` - (Optional) Maximum budget per model. This allows setting different budget limits for each model.
 
-* `model_rpm_limit` - (Optional) Requests per minute limit per model.
+* `model_rpm_limit` - (Optional) Requests per minute limit per model. This allows setting different RPM limits for each model.
 
-* `model_tpm_limit` - (Optional) Tokens per minute limit per model.
+* `model_tpm_limit` - (Optional) Tokens per minute limit per model. This allows setting different TPM limits for each model.
 
-* `guardrails` - (Optional) List of guardrails applied to this key.
+* `guardrails` - (Optional) List of guardrails applied to this key. This can be used to enforce certain safety or quality checks.
 
-* `blocked` - (Optional) Whether this key is blocked.
+* `blocked` - (Optional) Whether this key is blocked. If set to true, the key will be unable to make any requests.
 
-* `tags` - (Optional) List of tags associated with this key.
+* `tags` - (Optional) List of tags associated with this key. This can be used for organization and filtering of keys.
 
 ## Attribute Reference
 
@@ -131,7 +110,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `token_id` - The SHA-256 hash of the key. Used as the Terraform resource ID. Safe to store in state — cannot be used to authenticate against the LiteLLM API.
 
-* `spend` - The current spend for this key.
+* `spend` - The current spend for this key. This reflects the total amount spent using this key so far.
 
 ## Security Notes
 

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -2,46 +2,76 @@
 
 Manages a LiteLLM API key.
 
+> **Requires Terraform 1.11+** — this resource uses write-only attributes to prevent the API key from being stored in Terraform state.
+
 ## Example Usage
+
+### Basic key
 
 ```hcl
 resource "litellm_key" "example" {
-  models               = ["gpt-3.5-turbo", "gpt-4"]
-  max_budget           = 100.0
-  user_id              = "user123"
-  team_id              = "team456"
+  key_alias = "prod-key-1"
+  models    = ["gpt-4", "claude-3.5-sonnet"]
+}
+```
+
+### Pipe key to AWS SSM during apply
+
+Since the `key` value is write-only, it is only available during the initial `terraform apply`. Use it immediately to store it in a secrets manager:
+
+```hcl
+resource "litellm_key" "example" {
+  key_alias = "prod-key-1"
+  models    = ["gpt-4", "claude-3.5-sonnet"]
+}
+
+resource "aws_ssm_parameter" "litellm_key" {
+  name  = "/myapp/litellm-key"
+  type  = "SecureString"
+  value = litellm_key.example.key
+}
+```
+
+### Full example
+
+```hcl
+resource "litellm_key" "example" {
+  models                = ["gpt-3.5-turbo", "gpt-4"]
+  max_budget            = 100.0
+  user_id               = "user123"
+  team_id               = "team456"
   max_parallel_requests = 5
-  metadata             = {
+  metadata = {
     "environment" = "production"
   }
-  tpm_limit            = 1000
-  rpm_limit            = 60
-  budget_duration      = "monthly"
+  tpm_limit              = 1000
+  rpm_limit              = 60
+  budget_duration        = "monthly"
   allowed_cache_controls = ["no-cache", "max-age=3600"]
-  soft_budget          = 80.0
-  key_alias            = "prod-key-1"
-  duration             = "30d"
-  aliases              = {
+  soft_budget            = 80.0
+  key_alias              = "prod-key-1"
+  duration               = "30d"
+  aliases = {
     "gpt-3.5-turbo" = "chatgpt"
   }
-  config               = {
+  config = {
     "default_model" = "gpt-3.5-turbo"
   }
-  permissions          = {
+  permissions = {
     "can_create_keys" = "true"
   }
-  model_max_budget     = {
+  model_max_budget = {
     "gpt-4" = 50.0
   }
-  model_rpm_limit      = {
+  model_rpm_limit = {
     "gpt-3.5-turbo" = 30
   }
-  model_tpm_limit      = {
+  model_tpm_limit = {
     "gpt-4" = 500
   }
-  guardrails           = ["content_filter", "token_limit"]
-  blocked              = false
-  tags                 = ["production", "api"]
+  guardrails = ["content_filter", "token_limit"]
+  blocked    = false
+  tags       = ["production", "api"]
 }
 ```
 
@@ -49,68 +79,74 @@ resource "litellm_key" "example" {
 
 The following arguments are supported:
 
-* `models` - (Optional) List of models that can be used with this key. This restricts the key to only use the specified models.
+* `models` - (Optional) List of models that can be used with this key.
 
-* `max_budget` - (Optional) Maximum budget for this key. This sets an upper limit on the total spend allowed for this key.
+* `max_budget` - (Optional) Maximum budget for this key.
 
-* `user_id` - (Optional) User ID associated with this key. This links the key to a specific user in the LiteLLM system.
+* `user_id` - (Optional) User ID associated with this key.
 
-* `team_id` - (Optional) Team ID associated with this key. This links the key to a specific team in the LiteLLM system.
+* `team_id` - (Optional) Team ID associated with this key.
 
-* `max_parallel_requests` - (Optional) Maximum number of parallel requests allowed for this key. This helps in controlling concurrent usage.
+* `max_parallel_requests` - (Optional) Maximum number of parallel requests allowed for this key.
 
-* `metadata` - (Optional) Metadata associated with this key. This can be used to store additional, custom information about the key.
+* `metadata` - (Optional) Metadata associated with this key.
 
-* `tpm_limit` - (Optional) Tokens per minute limit for this key. This sets a rate limit based on the number of tokens processed.
+* `tpm_limit` - (Optional) Tokens per minute limit for this key.
 
-* `rpm_limit` - (Optional) Requests per minute limit for this key. This sets a rate limit based on the number of API calls.
+* `rpm_limit` - (Optional) Requests per minute limit for this key.
 
-* `budget_duration` - (Optional) Duration for the budget (e.g., "monthly", "weekly"). This defines the time period for which the `max_budget` applies.
+* `budget_duration` - (Optional) Duration for the budget (e.g., `"monthly"`, `"weekly"`).
 
-* `allowed_cache_controls` - (Optional) List of allowed cache control directives. This can be used to control caching behavior for requests made with this key.
+* `allowed_cache_controls` - (Optional) List of allowed cache control directives.
 
-* `soft_budget` - (Optional) Soft budget limit for this key. This can be used to set a warning threshold before reaching the `max_budget`.
+* `soft_budget` - (Optional) Soft budget limit for this key.
 
-* `key_alias` - (Optional) Alias for this key. This provides a human-readable identifier for the key.
+* `key_alias` - (Optional) Alias for this key.
 
-* `duration` - (Optional) Duration for which this key is valid. This sets an expiration time for the key.
+* `duration` - (Optional) Duration for which this key is valid (e.g., `"30d"`).
 
-* `aliases` - (Optional) Map of model aliases. This allows you to create custom names for models when using this key.
+* `aliases` - (Optional) Map of model aliases.
 
-* `config` - (Optional) Configuration options for this key. This can be used to set key-specific settings.
+* `config` - (Optional) Configuration options for this key.
 
-* `permissions` - (Optional) Permissions associated with this key. This defines what actions are allowed with this key.
+* `permissions` - (Optional) Permissions associated with this key.
 
-* `model_max_budget` - (Optional) Maximum budget per model. This allows setting different budget limits for each model.
+* `model_max_budget` - (Optional) Maximum budget per model.
 
-* `model_rpm_limit` - (Optional) Requests per minute limit per model. This allows setting different RPM limits for each model.
+* `model_rpm_limit` - (Optional) Requests per minute limit per model.
 
-* `model_tpm_limit` - (Optional) Tokens per minute limit per model. This allows setting different TPM limits for each model.
+* `model_tpm_limit` - (Optional) Tokens per minute limit per model.
 
-* `guardrails` - (Optional) List of guardrails applied to this key. This can be used to enforce certain safety or quality checks.
+* `guardrails` - (Optional) List of guardrails applied to this key.
 
-* `blocked` - (Optional) Whether this key is blocked. If set to true, the key will be unable to make any requests.
+* `blocked` - (Optional) Whether this key is blocked.
 
-* `tags` - (Optional) List of tags associated with this key. This can be used for organization and filtering of keys.
+* `tags` - (Optional) List of tags associated with this key.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `key` - The generated API key. This is the actual key value that will be used for authentication.
+* `key` - (Write-only) The generated API key. Available during `terraform apply` but **never stored in Terraform state**. Use it immediately to write to a secrets manager. Cannot be retrieved after the apply completes.
 
-* `spend` - The current spend for this key. This reflects the total amount spent using this key so far.
+* `token_id` - The SHA-256 hash of the key. Used as the Terraform resource ID. Safe to store in state — cannot be used to authenticate against the LiteLLM API.
 
-## State Management
+* `spend` - The current spend for this key.
 
-Recent updates have improved how the Key resource manages its state. The provider now ensures that all non-zero and non-empty values are correctly persisted in the Terraform state file. This means that any value you set will be accurately reflected in your state, preventing unnecessary updates and ensuring consistency between your configuration and the actual resource state.
+## Security Notes
+
+The `key` attribute is write-only (requires Terraform 1.11+). This means:
+
+- The raw key value is **never written to the Terraform state file**
+- It is available during `terraform apply` so you can reference it in other resources (e.g., `aws_ssm_parameter`, `kubernetes_secret`)
+- After the apply completes, it cannot be retrieved — plan accordingly
 
 ## Import
 
-LiteLLM keys can be imported using the `id`, e.g.,
+LiteLLM keys can be imported using the `token_id` (SHA-256 hash of the key), e.g.:
 
 ```
-$ terraform import litellm_key.example 12345
+$ terraform import litellm_key.example <token_id>
 ```
 
-This allows you to import existing keys into your Terraform state, enabling management of keys that were created outside of Terraform.
+The `token_id` can be found via the LiteLLM UI or by calling `GET /key/info?key=<your-key>`.


### PR DESCRIPTION
Updates README.md and docs/resources/key.md to reflect the v0.2.0 breaking changes — write-only `key` attribute, `token_id` as resource ID, Terraform 1.11+ requirement, and import instructions.