### PR TITLE
Fix: use pointer types for nullable fields in team and org resources

### DIFF
--- a/litellm/resource_organization.go
+++ b/litellm/resource_organization.go
@@ -133,10 +133,16 @@ func resourceLiteLLMOrganizationRead(d *schema.ResourceData, m interface{}) erro
 		d.Set("models", d.Get("models"))
 	}
 
-	d.Set("max_budget", GetFloatValue(orgResp.MaxBudget, d.Get("max_budget").(float64)))
+	if orgResp.MaxBudget != nil {
+		d.Set("max_budget", *orgResp.MaxBudget)
+	}
 	d.Set("budget_duration", GetStringValue(orgResp.BudgetDuration, d.Get("budget_duration").(string)))
-	d.Set("tpm_limit", GetIntValue(orgResp.TPMLimit, d.Get("tpm_limit").(int)))
-	d.Set("rpm_limit", GetIntValue(orgResp.RPMLimit, d.Get("rpm_limit").(int)))
+	if orgResp.TPMLimit != nil {
+		d.Set("tpm_limit", *orgResp.TPMLimit)
+	}
+	if orgResp.RPMLimit != nil {
+		d.Set("rpm_limit", *orgResp.RPMLimit)
+	}
 	d.Set("blocked", GetBoolValue(orgResp.Blocked, d.Get("blocked").(bool)))
 
 	log.Printf("[INFO] Successfully read organization with ID: %s", d.Id())

--- a/litellm/resource_team.go
+++ b/litellm/resource_team.go
@@ -133,9 +133,15 @@ func resourceLiteLLMTeamRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("metadata", d.Get("metadata"))
 	}
 
-	d.Set("tpm_limit", GetIntValue(teamResp.TPMLimit, d.Get("tpm_limit").(int)))
-	d.Set("rpm_limit", GetIntValue(teamResp.RPMLimit, d.Get("rpm_limit").(int)))
-	d.Set("max_budget", GetFloatValue(teamResp.MaxBudget, d.Get("max_budget").(float64)))
+	if teamResp.TPMLimit != nil {
+		d.Set("tpm_limit", *teamResp.TPMLimit)
+	}
+	if teamResp.RPMLimit != nil {
+		d.Set("rpm_limit", *teamResp.RPMLimit)
+	}
+	if teamResp.MaxBudget != nil {
+		d.Set("max_budget", *teamResp.MaxBudget)
+	}
 	d.Set("budget_duration", GetStringValue(teamResp.BudgetDuration, d.Get("budget_duration").(string)))
 
 	// Handle models separately as it's a list

--- a/litellm/types.go
+++ b/litellm/types.go
@@ -39,9 +39,9 @@ type TeamResponse struct {
 	TeamAlias             string                 `json:"team_alias,omitempty"`
 	OrganizationID        string                 `json:"organization_id,omitempty"`
 	Metadata              map[string]interface{} `json:"metadata,omitempty"`
-	TPMLimit              int                    `json:"tpm_limit,omitempty"`
-	RPMLimit              int                    `json:"rpm_limit,omitempty"`
-	MaxBudget             float64                `json:"max_budget,omitempty"`
+	TPMLimit              *int                   `json:"tpm_limit,omitempty"`
+	RPMLimit              *int                   `json:"rpm_limit,omitempty"`
+	MaxBudget             *float64               `json:"max_budget,omitempty"`
 	BudgetDuration        string                 `json:"budget_duration,omitempty"`
 	Models                []string               `json:"models"`
 	Blocked               bool                   `json:"blocked,omitempty"`
@@ -54,10 +54,10 @@ type OrganizationResponse struct {
 	OrganizationAlias string                 `json:"organization_alias,omitempty"`
 	Metadata          map[string]interface{} `json:"metadata,omitempty"`
 	Models            []string               `json:"models,omitempty"`
-	MaxBudget         float64                `json:"max_budget,omitempty"`
+	MaxBudget         *float64               `json:"max_budget,omitempty"`
 	BudgetDuration    string                 `json:"budget_duration,omitempty"`
-	TPMLimit          int                    `json:"tpm_limit,omitempty"`
-	RPMLimit          int                    `json:"rpm_limit,omitempty"`
+	TPMLimit          *int                   `json:"tpm_limit,omitempty"`
+	RPMLimit          *int                   `json:"rpm_limit,omitempty"`
 	Blocked           bool                   `json:"blocked,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- Fixes #29
- Changes `tpm_limit`, `rpm_limit`, and `max_budget` in `TeamResponse` and `OrganizationResponse` to pointer types (`*int`, `*float64`)
- Updates Read functions to only set these fields in state when the API returns a non-nil value, preventing zero-value diffs on every `terraform plan`

## Test plan

- [ ] Create a team/org resource without `tpm_limit`, `rpm_limit`, or `max_budget` set
- [ ] Run `terraform plan` after apply — should show no changes