### PR TITLE
[Infra] Add manual approval gate to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,16 @@ permissions:
   contents: write
 
 jobs:
+  approve:
+    name: Approval gate
+    runs-on: ubuntu-latest
+    environment: production-release
+    steps:
+      - name: Approved
+        run: echo "Release approved"
+
   goreleaser:
+    needs: approve
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
## Relevant issues

## Summary

The release workflow publishes on every `v*` tag push with no human checkpoint, so an accidental or unauthorized tag push triggers a release immediately.

### Fix

Adds an `approve` job that pins to a `production-release` GitHub Environment. The existing `goreleaser` job now depends on it via `needs: approve`, so the release pauses until a required reviewer approves the pending deployment.

## Changes

Added an `approve` job to `.github/workflows/release.yml` that gates `goreleaser` behind the `production-release` environment. The environment's required reviewers, self-review prevention, and tag restrictions will be configured in the GitHub UI.

## Testing

- Will be verified end-to-end after the `production-release` environment is configured in repo settings with required reviewers. Pushing a `v*` tag should pause on the approval gate until a reviewer approves.

## Type

🚄 Infrastructure

## Screenshots