### PR TITLE
fix(): increase retry window to handle multi-replica cache propagation delay

### DIFF
--- a/litellm/resource_model_crud.go
+++ b/litellm/resource_model_crud.go
@@ -16,8 +16,8 @@ import (
 // It handles the case where resourceLiteLLMModelRead returns nil but clears the ID
 // (eventual consistency: model created but not yet visible on read-back).
 func retryModelRead(d *schema.ResourceData, m interface{}, maxRetries int) error {
-	delay := 1 * time.Second
-	maxDelay := 10 * time.Second
+	delay := 2 * time.Second
+	maxDelay := 30 * time.Second
 	modelID := d.Id()
 
 	for i := 0; i < maxRetries; i++ {
@@ -271,7 +271,7 @@ func createOrUpdateModel(d *schema.ResourceData, m interface{}, isUpdate bool) e
 
 	log.Printf("[INFO] Model created with ID %s. Starting retry mechanism to read the model...", modelID)
 	// Read back the resource with retries to ensure the state is consistent
-	return retryModelRead(d, m, 5)
+	return retryModelRead(d, m, 10)
 }
 
 func resourceLiteLLMModelCreate(d *schema.ResourceData, m interface{}) error {

--- a/litellm/resource_model_crud_test.go
+++ b/litellm/resource_model_crud_test.go
@@ -1,0 +1,211 @@
+package litellm
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// notFoundBody returns a JSON body that triggers isModelNotFoundError via the detail.error path.
+func notFoundBody() []byte {
+	return []byte(`{"detail": {"error": "Model id = test-id not found on litellm proxy"}}`)
+}
+
+// newTestModelResourceData creates *schema.ResourceData for the model resource,
+// pre-populated with required fields and the given ID.
+func newTestModelResourceData(t *testing.T, id string) *schema.ResourceData {
+	t.Helper()
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMModel().Schema, map[string]interface{}{
+		"model_name":                         "test-model",
+		"custom_llm_provider":                "vertex_ai",
+		"base_model":                         "claude-sonnet-4-5",
+		"tier":                               "enterprise",
+		"mode":                               "chat",
+		"tpm":                                0,
+		"rpm":                                0,
+		"thinking_enabled":                   false,
+		"thinking_budget_tokens":             1024,
+		"merge_reasoning_content_in_choices": false,
+	})
+	d.SetId(id)
+	return d
+}
+
+// successBody returns a JSON body that handleAPIResponse can parse into a ModelResponse.
+func successBody(id string) []byte {
+	resp := ModelResponse{
+		ModelName: "test-model",
+		LiteLLMParams: LiteLLMParams{
+			CustomLLMProvider: "vertex_ai",
+			Model:             "vertex_ai/claude-sonnet-4-5",
+		},
+		ModelInfo: ModelInfo{
+			ID:        id,
+			BaseModel: "claude-sonnet-4-5",
+			Tier:      "enterprise",
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func TestRetryModelRead_SuccessOnFirstAttempt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(successBody("test-id"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newTestModelResourceData(t, "test-id")
+
+	err := retryModelRead(d, client, 10)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if d.Id() != "test-id" {
+		t.Fatalf("expected ID 'test-id', got %q", d.Id())
+	}
+}
+
+// TestRetryModelRead_SuccessAfterRetries simulates the core race condition:
+// the model is not yet visible on the first reads (cache miss → 404),
+// then becomes visible on the 4th attempt.
+func TestRetryModelRead_SuccessAfterRetries(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n <= 3 {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write(notFoundBody())
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(successBody("test-id"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newTestModelResourceData(t, "test-id")
+
+	err := retryModelRead(d, client, 10)
+	if err != nil {
+		t.Fatalf("expected nil error after eventual success, got: %v", err)
+	}
+	if d.Id() != "test-id" {
+		t.Fatalf("expected ID 'test-id', got %q", d.Id())
+	}
+	if atomic.LoadInt32(&callCount) != 4 {
+		t.Fatalf("expected 4 HTTP calls (3 misses + 1 hit), got %d", callCount)
+	}
+}
+
+// TestRetryModelRead_ExhaustsRetries verifies that after all attempts the function
+// returns an error describing the exhaustion (not "model_not_found") and preserves the ID.
+func TestRetryModelRead_ExhaustsRetries(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(notFoundBody())
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newTestModelResourceData(t, "test-id")
+
+	err := retryModelRead(d, client, 3)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	if atomic.LoadInt32(&callCount) != 3 {
+		t.Fatalf("expected exactly 3 HTTP calls, got %d", callCount)
+	}
+	// ID must still be set so Terraform can retry on next apply
+	if d.Id() != "test-id" {
+		t.Fatalf("expected ID to be preserved as 'test-id', got %q", d.Id())
+	}
+}
+
+// TestRetryModelRead_IDRestoredBetweenRetries verifies that resourceLiteLLMModelRead
+// clears the ID on a 404 and that retryModelRead restores it before the next attempt,
+// allowing the URL in the subsequent GET to still carry the correct model ID.
+func TestRetryModelRead_IDRestoredBetweenRetries(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write(notFoundBody())
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(successBody("my-model-id"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newTestModelResourceData(t, "my-model-id")
+
+	err := retryModelRead(d, client, 2)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if d.Id() != "my-model-id" {
+		t.Fatalf("expected ID 'my-model-id', got %q", d.Id())
+	}
+}
+
+// TestRetryModelRead_ServerError verifies that a 500 response is eventually
+// surfaced as an error after all retries are exhausted and that the error
+// message is not "model_not_found" (to distinguish it from cache-miss errors).
+func TestRetryModelRead_ServerError(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error": {"message": "internal server error"}}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newTestModelResourceData(t, "test-id")
+
+	const maxRetries = 2
+	err := retryModelRead(d, client, maxRetries)
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+	// retryModelRead retries on all errors; verify it exhausted the full count.
+	if atomic.LoadInt32(&callCount) != maxRetries {
+		t.Fatalf("expected %d HTTP calls, got %d", maxRetries, callCount)
+	}
+	// The error must not look like a model_not_found (which would clear state).
+	if err.Error() == "model_not_found" {
+		t.Fatal("500 error must not be reported as model_not_found")
+	}
+}
+
+// TestRetryModelRead_ConnectionError verifies that a connection-level failure
+// (server closed) is also surfaced without looping indefinitely.
+func TestRetryModelRead_ConnectionError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // closed immediately
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newTestModelResourceData(t, "test-id")
+
+	err := retryModelRead(d, client, 3)
+	if err == nil {
+		t.Fatal("expected error for connection failure, got nil")
+	}
+	fmt.Printf("connection error (expected): %v\n", err)
+}


### PR DESCRIPTION
## Why

The Terraform provider randomly fails with:

```
Error: Provider produced inconsistent result after apply
Root object was present, but now absent.
```

This occurs ~50% of the time when deploying `litellm_model` resources against a multi-replica LiteLLM deployment. The model **is** created successfully in LiteLLM but Terraform discards it from state, producing orphan resources.

**Root cause:** After `POST /model/new`, Terraform performs an implicit Read-after-Apply via `GET /model/info`. With multiple replicas behind a load balancer, the read request may hit a different pod whose in-memory router cache hasn't yet been reloaded from the database. The pod returns 400 "model not found", the provider sets `d.SetId("")`, and Terraform marks the resource as absent.

The provider already has retry logic (`retryModelRead`) to handle this eventual consistency, but the retry window was too narrow (max ~50s over 5 attempts with 1s initial delay) to survive under concurrent deployments (`for_each` across multiple vertex projects).

Related: MLP-6153

## How

Widen the retry window in `retryModelRead`:
- Initial delay: `1s → 2s`
- Max delay: `10s → 30s`
- Retry count: `5 → 10`

This gives the server-side cache up to ~4 minutes of total retry time to propagate, accommodating both DB replication lag and pod cache reload time under load.

## Changes

- **`litellm/resource_model_crud.go`** — Updated `retryModelRead` timing parameters and call-site retry count.
- **`litellm/resource_model_crud_test.go`** — 6 new Go unit tests using `httptest`: success on first attempt, success after multiple cache-miss retries (the core race scenario), retry exhaustion with ID preserved, ID restoration between retries, 500 server errors surfaced after exhaustion, connection errors surfaced after exhaustion.

## Evidence of Testing

All 6 unit tests pass (`go test ./litellm/... -run TestRetryModelRead -v`):
- `TestRetryModelRead_SuccessOnFirstAttempt` — PASS
- `TestRetryModelRead_SuccessAfterRetries` — PASS (simulates 3 cache misses then success)
- `TestRetryModelRead_ExhaustsRetries` — PASS
- `TestRetryModelRead_IDRestoredBetweenRetries` — PASS
- `TestRetryModelRead_ServerError` — PASS
- `TestRetryModelRead_ConnectionError` — PASS

Note: a complementary server-side fix (reloading the router cache on `/model/info` miss) has been applied to the LiteLLM application. This provider-side change is a defence-in-depth measure that remains valuable for deployments running older LiteLLM versions.

## Review Focus

- Are the new timing values (`2s` initial, `30s` max, `10` attempts) reasonable for upstream acceptance? Open to adjustment.
- The test for `SuccessAfterRetries` takes ~14s due to real `time.Sleep` — is that acceptable, or should we inject a clock interface for faster tests?