### PR TITLE
fix: add support for http proxy

### DIFF
--- a/litellm/client.go
+++ b/litellm/client.go
@@ -22,9 +22,8 @@ type Client struct {
 }
 
 func NewClient(apiBase, apiKey string, insecureSkipVerify bool) *Client {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
-	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecureSkipVerify}
 
 	return &Client{
 		APIBase:            apiBase,


### PR DESCRIPTION
## Summary

Fixes proxy support for the LiteLLM provider HTTP client.

The provider created a custom `http.Transport` to support `insecure_skip_verify`, but this bypassed Go’s default transport settings, including `ProxyFromEnvironment`. As a result, standard proxy environment variables like `HTTP_PROXY` and `HTTPS_PROXY` were ignored.

This change clones `http.DefaultTransport` and only overrides the TLS configuration, preserving proxy behavior and the rest of Go’s default HTTP transport settings.

## Testing

Tested locally by using the provider behind an HTTP/HTTPS proxy and confirming Terraform can connect to the LiteLLM API.
