### PR TITLE
fix(key): include tags in UpdateKey payload

### DIFF
--- a/litellm/client.go
+++ b/litellm/client.go
@@ -158,6 +158,9 @@ func (c *Client) UpdateKey(key *Key) (*Key, error) {
 	if len(key.Guardrails) > 0 {
 		updateData["guardrails"] = key.Guardrails
 	}
+	if len(key.Tags) > 0 {
+		updateData["tags"] = key.Tags
+	}
 
 	resp, err := c.sendRequest("POST", "/key/update", updateData)
 	if err != nil {


### PR DESCRIPTION
## Summary

`UpdateKey()` in `litellm/client.go` builds the JSON body for `POST /key/update` but never adds the `tags` field to it. As a result, any change to `tags` on an existing `litellm_key` is silently dropped on apply — `terraform plan` shows the diff, the API call returns `200`, the key's `updated_at` advances, but the backend leaves `tags` unchanged because the field is not in the request body.

The Create path already sends `tags` (see [`resource_key_utils.go:85-90`](https://github.com/BerriAI/terraform-provider-litellm/blob/main/litellm/resource_key_utils.go#L85-L90)), so initial key creation works as expected. Only subsequent in-place updates are broken.

## Change

Mirror the existing pattern used for `models` and `guardrails` (lines just above): include the field in `updateData` when the slice is non-empty.

```diff
 if len(key.Guardrails) > 0 {
     updateData["guardrails"] = key.Guardrails
 }
+if len(key.Tags) > 0 {
+    updateData["tags"] = key.Tags
+}
```

## Repro (before this PR)

1. `resource "litellm_key" "example" { ... tags = ["a", "b"] }` → apply → tags `["a", "b"]` appear on the key ✅
2. Change to `tags = ["a", "b", "c"]` → apply → "Updated", `updated_at` advances, but key still has `["a", "b"]` ❌

Confirmed against a LiteLLM gateway running `v1.83.10` using provider `v0.1.2`. Checked the request payload via the gateway-side update path and via `GET /key/info` showing `tags` unchanged after apply.

## Verification

- `go build ./...` passes.
- The fix follows the same pattern as the adjacent `models` and `guardrails` handling, so the failure mode is identical (only the omission was inconsistent).

## Known follow-up (not addressed here)

Like `models` and `guardrails`, the `len > 0` guard means users still can't clear `tags` back to an empty list via update. Fixing that requires distinguishing "unset" from "explicitly empty" (e.g., a pointer or always sending the slice). Left out of this PR to keep the fix minimal and consistent with adjacent code; happy to follow up if maintainers prefer a broader change.