### PR TITLE
docs: v0.2.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-05-13
+
+### Fixed
+
+- **key**: Include `tags` in `UpdateKey` payload so tag changes on an existing `litellm_key` are applied on update instead of being silently dropped (#41)
+
 ## [0.2.1] - 2026-04-13
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds the `v0.2.2` entry to `CHANGELOG.md`, covering the single user-facing fix that landed on `main` since `v0.2.1`:

- [#41](https://github.com/BerriAI/terraform-provider-litellm/pull/41) `fix(key): include tags in UpdateKey payload` — tag changes on an existing `litellm_key` were silently dropped on update.

The other commit on `main` since `v0.2.1` ([#37](https://github.com/BerriAI/terraform-provider-litellm/pull/37), release-workflow approval gate) is CI-only and intentionally not listed.

## Release process

After merge:

1. Tag `v0.2.2` at the merge commit and push the tag.
2. The `Release` workflow fires on `push.tags: 'v*'` and pauses at the `production-release` approval gate (added in #37).
3. Approve in the Actions UI → GoReleaser publishes the GitHub Release + signed binaries → Terraform Registry mirrors.

## Test plan

- [ ] Confirm `CHANGELOG.md` diff matches the structure of #33.
- [ ] After merge, push `v0.2.2` tag and approve the Release workflow run.
- [ ] Verify the release appears at https://github.com/BerriAI/terraform-provider-litellm/releases/tag/v0.2.2 with signed binaries.
- [ ] Verify the version surfaces on the Terraform Registry within ~10 minutes.