### PR TITLE
fix(key): honor user-supplied write-only key value on create (#39)

### DIFF
--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -146,16 +146,31 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	key := &Key{}
 	mapResourceDataToKey(d, key)
 
+	// Honor a user-supplied "key" value. "key" is a write-only attribute, so
+	// d.Get("key") returns "" (the SDK clears write-only fields after plan).
+	// Read it from the raw config instead so a caller-provided key is sent to
+	// /key/generate. Scoped to Create only: the Update path reuses
+	// mapResourceDataToKey with key.Key set to the token ID and must not be
+	// overwritten here. See issue #39.
+	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
+		if rawKey := rawConfig.GetAttr("key"); !rawKey.IsNull() && rawKey.IsKnown() {
+			key.Key = rawKey.AsString()
+		}
+	}
+
 	createdKey, err := c.CreateKey(key)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating key: %s", err))
 	}
 
 	d.SetId(createdKey.TokenID)
-	// Set the write-only key value so it's available during this apply
-	// but will not be persisted to state.
+
+	// Re-set the write-only key value AFTER the read so it is available to
+	// downstream resources during this apply (Read does not repopulate
+	// write-only fields). See issue #39.
+	diags := resourceKeyRead(ctx, d, m)
 	d.Set("key", createdKey.Key)
-	return resourceKeyRead(ctx, d, m)
+	return diags
 }
 
 func resourceKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {


### PR DESCRIPTION
## What

Fixes https://github.com/BerriAI/terraform-provider-litellm/issues/39

`litellm_key` declares an optional write-only `key` attribute so a caller can supply a predetermined key value. That value is currently dropped: `mapResourceDataToKey` reads every field except `key`, so `Key.Key` is always empty when `CreateKey` is called, LiteLLM mints its own key, and there is no way to retrieve the resulting value from Terraform.

## Fix

Two changes, both in `resourceKeyCreate`:

1. Read the supplied `key` from the raw config. `d.Get("key")` returns `""` for write-only attributes (the SDK clears them after plan), so the value is read via `d.GetRawConfig().GetAttr("key")` and assigned to `key.Key` before `CreateKey`.
2. Re-set the write-only value with `d.Set("key", ...)` AFTER `resourceKeyRead` rather than before, so it is available to downstream resources during the apply.

## Why not change `mapResourceDataToKey`

The linked issue proposes reading `key` inside `mapResourceDataToKey`. That function is shared with `resourceKeyUpdate`, which calls it with `key.Key` already set to `d.Id()` (the token hash used as the update identifier). Reading the raw `key` there would overwrite that identifier on every update. Scoping the change to the create path avoids touching update behavior.

## Compatibility

No change to the common path. When `key` is not supplied, `key.Key` stays `""`, identical to today. Only a caller-provided value changes behavior, which is the intended use of the field.

## Testing

Validated locally against the official `ghcr.io/berriai/litellm-database:v1.87.1` image with a local Postgres, using a `dev_overrides` build of this branch.

Config:
```hcl
resource "litellm_key" "byo" {
  key       = "sk-byo-test-12345"
  key_alias = "byo-validation"
}
```

Result:
- `terraform apply` created the key; `token_id = 16007af15fd67f8e2dc948610e9bb2265472c3ccfb9274eb85c7b877ce64f31e`.
- `GET /key/info?key=sk-byo-test-12345` returns the key with `key_alias: byo-validation`, so the supplied value was registered verbatim.
- `sha256("sk-byo-test-12345")` equals that `token_id`, confirming the supplied key was used rather than a server-generated one.

The no-key path is unchanged: with `key` omitted, `key.Key` stays empty and LiteLLM generates the value as before.