### PR TITLE
fix(credential): adopt existing credential on name conflict instead of failing (#8)

### DIFF
--- a/litellm/resource_credential_crud.go
+++ b/litellm/resource_credential_crud.go
@@ -88,6 +88,15 @@ func resourceLiteLLMCredentialCreate(d *schema.ResourceData, m interface{}) erro
 
 	err = handleCredentialAPIResponse(resp, nil, client)
 	if err != nil {
+		// If a credential with this name already exists, adopt it instead of
+		// failing. credential_name is the natural key, so we take ownership and
+		// update the existing credential to match the configured values rather
+		// than erroring on the unique-constraint conflict. See issue #8.
+		if err.Error() == "credential_conflict" {
+			log.Printf("[WARN] Credential %q already exists; adopting it and updating to match configuration.", credentialName)
+			d.SetId(credentialName)
+			return resourceLiteLLMCredentialUpdate(d, m)
+		}
 		return fmt.Errorf("failed to create credential: %w", err)
 	}
 

--- a/litellm/utils.go
+++ b/litellm/utils.go
@@ -188,6 +188,27 @@ func isCredentialNotFoundError(errResp ErrorResponse) bool {
 	return false
 }
 
+// isCredentialConflictError checks if the error response indicates a credential
+// name collision. LiteLLM surfaces this as a 500 carrying the underlying Prisma
+// unique-constraint message on credential_name.
+func isCredentialConflictError(errResp ErrorResponse) bool {
+	if msg, ok := errResp.Error.Message.(string); ok {
+		if strings.Contains(msg, "Unique constraint failed") && strings.Contains(msg, "credential_name") {
+			return true
+		}
+	}
+
+	if msgMap, ok := errResp.Error.Message.(map[string]interface{}); ok {
+		if errStr, ok := msgMap["error"].(string); ok {
+			if strings.Contains(errStr, "Unique constraint failed") && strings.Contains(errStr, "credential_name") {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // handleCredentialAPIResponse handles API responses specifically for credential operations
 func handleCredentialAPIResponse(resp *http.Response, result interface{}, client *Client) error {
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
@@ -204,6 +225,9 @@ func handleCredentialAPIResponse(resp *http.Response, result interface{}, client
 		if err := json.Unmarshal(bodyBytes, &errResp); err == nil {
 			if isCredentialNotFoundError(errResp) {
 				return fmt.Errorf("credential_not_found")
+			}
+			if isCredentialConflictError(errResp) {
+				return fmt.Errorf("credential_conflict")
 			}
 		}
 		return fmt.Errorf("API request failed: Status: %s, Response: %s",


### PR DESCRIPTION
## What

Fixes https://github.com/BerriAI/terraform-provider-litellm/issues/8

`credential_name` is `ForceNew` and `resourceLiteLLMCredentialCreate` does a blind `POST /credentials`. Applying over a credential that already exists in LiteLLM (created out of band, or present from a prior run that left state) fails with:

```
failed to create credential: API request failed: Status: 500 Internal Server Error,
Response: {"error":{"message":"Unique constraint failed on the fields: (`credential_name`)","type":"internal_server_error","code":"500"}}
```

## Fix

Follows the existing sentinel pattern in this file (`credential_not_found` / `isCredentialNotFoundError`):

1. `isCredentialConflictError` (new) detects the unique-constraint message in the error response.
2. `handleCredentialAPIResponse` returns a `credential_conflict` sentinel for it.
3. `resourceLiteLLMCredentialCreate` catches that sentinel and adopts the existing credential: sets the ID to `credential_name` and calls the update path to make it match the configured values, rather than erroring.

Result: `apply` becomes idempotent over a pre-existing credential, which is the behavior the issue asks for ("I would expect credential to be overriden on name conflict").

## Design note

This takes ownership of an existing credential and updates it to match config. That is the requested behavior and is consistent with `credential_name` being the natural key, but it does mean an `apply` will adopt an unmanaged credential of the same name rather than refuse. Import (added in 321f63a) remains available for those who prefer explicit adoption. If you would rather surface an actionable "credential exists, import it" error instead of silent adoption, that is a one-line change from here, happy to switch it.

## Testing

Validated locally against `ghcr.io/berriai/litellm-database:v1.87.1` with a local Postgres, using a `dev_overrides` build of this branch.

Reproduction (before the fix): create a credential, `terraform state rm` it (so it stays in LiteLLM but leaves state), then re-apply. The create 500s with the unique-constraint error above.

With the fix, same sequence:
- `terraform apply` over the pre-existing credential: `litellm_credential.c: Creation complete [id=conflict-test]` (adopted, no error).
- Second `terraform apply`: `No changes. Your infrastructure matches the configuration.` (idempotent).

Note: on v1.87.1 the `/credentials` endpoint requires `credential_info` to be present (422 otherwise); unrelated to this change but worth flagging since the provider marks it Optional.