### PR TITLE
fix(key): force replacement when team_id changes to avoid updating a cascade-deleted key (#12)

### DIFF
--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -45,6 +45,11 @@ func resourceKey() *schema.Resource {
 			"team_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				// A LiteLLM key belongs to a team. Deleting/recreating the team
+				// cascade-deletes its keys, so changing team_id must replace the
+				// key (in dependency order) rather than issue an in-place update
+				// against a token that no longer exists. See issue #12.
+				ForceNew: true,
 			},
 			"max_parallel_requests": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
## What

Fixes https://github.com/BerriAI/terraform-provider-litellm/issues/12

A LiteLLM key belongs to a team, and deleting/recreating a team cascade-deletes its keys. Because `team_id` was a normal updatable attribute, recreating a team (for example renaming it, or any change that forces team replacement) left Terraform issuing an in-place `/key/update` against a token that no longer existed:

```
litellm_team.t: Destruction complete
litellm_team.t: Creation complete [id=<new>]
litellm_key.k: Modifying... [id=<old token>]
Error: error updating key: API request failed with status code 404: {"error":{"message":"Key not found."...}}
```

(The original report shows a 401; on current LiteLLM it is a 404. Same root cause: the key was cascade-deleted with its team.)

## Fix

Mark `team_id` as `ForceNew`. A `team_id` change now replaces the key instead of updating it. Terraform orders the replacement correctly: because the key depends on the team, it destroys the key first (while the old team still exists, so the delete succeeds), then destroys and recreates the team, then recreates the key against the new team.

## Behavior change

`team_id` is no longer updatable in place. Changing a key's team now replaces the key, which re-mints its value. This is the correct model given LiteLLM's cascade semantics (a key cannot outlive its team), but it is a behavior change for anyone who was relying on in-place team moves, so calling it out explicitly.

## Testing

Validated locally against `ghcr.io/berriai/litellm-database:v1.87.1` with a local Postgres, using a `dev_overrides` build of this branch.

Before (on `main`): a `team` + `key`, then `terraform apply -replace=litellm_team.t`. The team is destroyed and recreated, then the key `Modify` fails with the 404 above.

After (this branch): same sequence. The plan marks `team_id ... # forces replacement`, and apply runs cleanly in order:
```
litellm_key.k: Destroying...        -> complete   (key deleted while old team still exists)
litellm_team.t: Destroying...       -> complete
litellm_team.t: Creating...         -> complete [id=<new>]
litellm_key.k: Creating...          -> complete [id=<new token>]
Apply complete! Resources: 2 added, 0 changed, 2 destroyed.
```
No 404, no dead-token update.