### PR TITLE
feat(model): add pricing_base_model to decouple pricing from routing

### DIFF
--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -118,6 +118,8 @@ The following arguments are supported:
 
 * `base_model` - (Required) string. The actual model identifier from the provider (e.g., "gpt-4", "claude-2").
 
+* `pricing_base_model` - (Optional) string. A pricing key fed to `model_info.base_model` **independently of routing**. When set, `litellm_params.model` still routes via `base_model`, but LiteLLM looks up cost against this key. Useful when the routing/deployment name differs from the cost-map key — e.g. an Azure deployment routed as `azure/gpt-4.1` whose real tier is Data Zone: set `pricing_base_model = "us/gpt-4.1-2025-04-14"` so it is billed at the Data Zone rate. When unset, `base_model` drives pricing as before.
+
 * `litellm_credential_name` - (Optional) string. Name of a LiteLLM credential to use for this model.
 
 * `tier` - (Optional) string. The usage tier for this model. Valid values are `"free"` or `"paid"`. Default: `"free"`.

--- a/litellm/resource_model.go
+++ b/litellm/resource_model.go
@@ -73,6 +73,14 @@ func resourceLiteLLMModel() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"pricing_base_model": {
+				// Optional pricing key fed to model_info.base_model, DECOUPLED
+				// from routing. When set, litellm_params.model still routes via
+				// base_model, but cost is looked up against this key (e.g.
+				// "us/gpt-4.1-2025-04-14" for Azure Data Zone pricing).
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"tier": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/litellm/resource_model_crud.go
+++ b/litellm/resource_model_crud.go
@@ -68,6 +68,14 @@ func createOrUpdateModel(d *schema.ResourceData, m interface{}, isUpdate bool) e
 	baseModel := d.Get("base_model").(string)
 	modelName := fmt.Sprintf("%s/%s", customLLMProvider, baseModel)
 
+	// Pricing base_model, decoupled from routing. When pricing_base_model is
+	// set it feeds model_info.base_model (the cost-lookup key) WITHOUT changing
+	// the routing string above; otherwise base_model drives pricing as before.
+	pricingBaseModel := baseModel
+	if v, ok := d.GetOk("pricing_base_model"); ok && v.(string) != "" {
+		pricingBaseModel = v.(string)
+	}
+
 	// Generate a UUID for new models
 	modelID := d.Id()
 	if !isUpdate {
@@ -240,7 +248,7 @@ func createOrUpdateModel(d *schema.ResourceData, m interface{}, isUpdate bool) e
 		ModelInfo: ModelInfo{
 			ID:        modelID,
 			DBModel:   true,
-			BaseModel: baseModel,
+			BaseModel: pricingBaseModel,
 			Tier:      d.Get("tier").(string),
 			Mode:      d.Get("mode").(string),
 			TeamID:    d.Get("team_id").(string),
@@ -306,7 +314,16 @@ func resourceLiteLLMModelRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("rpm", GetIntValue(modelResp.LiteLLMParams.RPM, d.Get("rpm").(int)))
 	d.Set("model_api_base", GetStringValue(modelResp.LiteLLMParams.APIBase, d.Get("model_api_base").(string)))
 	d.Set("api_version", GetStringValue(modelResp.LiteLLMParams.APIVersion, d.Get("api_version").(string)))
-	d.Set("base_model", GetStringValue(modelResp.ModelInfo.BaseModel, d.Get("base_model").(string)))
+	// base_model / pricing_base_model read-back. When pricing_base_model is
+	// configured, model_info.base_model holds the PRICING key, so recover the
+	// routing base_model from state (not returned by the API) and read
+	// pricing_base_model from model_info.
+	if pbm, ok := d.GetOk("pricing_base_model"); ok && pbm.(string) != "" {
+		d.Set("base_model", d.Get("base_model").(string))
+		d.Set("pricing_base_model", GetStringValue(modelResp.ModelInfo.BaseModel, pbm.(string)))
+	} else {
+		d.Set("base_model", GetStringValue(modelResp.ModelInfo.BaseModel, d.Get("base_model").(string)))
+	}
 	d.Set("tier", GetStringValue(modelResp.ModelInfo.Tier, d.Get("tier").(string)))
 	d.Set("mode", GetStringValue(modelResp.ModelInfo.Mode, d.Get("mode").(string)))
 	d.Set("team_id", GetStringValue(modelResp.ModelInfo.TeamID, d.Get("team_id").(string)))


### PR DESCRIPTION
## Problem

`base_model` currently drives **two** things at once:
- routing: `litellm_params.model = "<custom_llm_provider>/<base_model>"`
- pricing: `model_info.base_model` (the cost-map lookup key)

When the deployment's routing name differs from the cost-map key, there's no way to get correct pricing without breaking routing.

**Concrete case — Azure OpenAI Data Zone.** The `model_prices_and_context_window.json` map has `azure/us/gpt-4.1-2025-04-14` ($2.20/$8.80, Data Zone) but the Azure deployment is routed as `azure/gpt-4.1`. Today, to make LiteLLM price it at Data Zone you'd set:

```hcl
base_model = "us/gpt-4.1-2025-04-14"
```

…but that also rewrites routing to `litellm_params.model = "azure/us/gpt-4.1-2025-04-14"` → Azure has no deployment by that name → **404**. So Data Zone deployments get under-billed at the Global rate, and there's no clean fix from the provider.

## Fix

Add an optional `pricing_base_model` attribute that feeds `model_info.base_model` **independently of routing**:

```hcl
resource "litellm_model" "gpt_4_1" {
  model_name          = "gpt-4.1"
  custom_llm_provider = "azure"
  base_model          = "gpt-4.1"                # routing → azure/gpt-4.1 (real deployment)
  pricing_base_model  = "us/gpt-4.1-2025-04-14"  # pricing → Data Zone $2.20/$8.80
}
```

- When `pricing_base_model` is set, `model_info.base_model` uses it while `litellm_params.model` still routes via `base_model`.
- When unset, behaviour is **unchanged** (`base_model` drives both) — fully backwards compatible.
- The read path recovers `base_model` from state (it isn't returned by the API in the routing form) to avoid perpetual diffs.

## Changes
- `litellm/resource_model.go` — new optional `pricing_base_model` schema attribute.
- `litellm/resource_model_crud.go` — create path sets `ModelInfo.BaseModel` from `pricing_base_model` when present; read path handles the decoupled case drift-free.
- `docs/resources/model.md` — document the attribute.

## Testing

Verified end-to-end against a local LiteLLM `v1.90.0` + a **real Azure `gpt-4.1` deployment**, using this provider built locally via `dev_overrides`:

- `litellm_params.model = azure/gpt-4.1` → routing succeeds (real 200 response)
- `model_info.base_model = us/gpt-4.1-2025-04-14` → request **billed at Data Zone**: `$0.00002640` for 8in/1out = exactly `$2.20/$8.80` (1.100× Global)
- `terraform plan` after apply → **No changes** (drift-free)

Baseline (without the fix) reproduces the 404 on the same setup.