### PR TITLE
ci: run the release workflow unattended

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,15 @@ name: Release
 
 # This GitHub action creates a release when a tag that matches the pattern
 # "v*" (e.g. v0.1.0) is created.
+#
+# It runs unattended, by design. This repository is a release mirror of
+# BerriAI/litellm//terraform/provider, and the only thing that creates a v* tag
+# here is project-releaser's publish-terraform-provider.yml, using a token held
+# in that private repo. That workflow already carries a production-release
+# approval, and the source it mirrors was already reviewed as a litellm PR
+# under gofmt, go vet, build, test, and the endpoint-drift audit. A second
+# approval here re-gated the same decision in a second repo, so releases sat
+# waiting on someone noticing a run in a repo nobody watches.
 on:
   push:
     tags:
@@ -14,16 +23,7 @@ permissions:
   contents: write
 
 jobs:
-  approve:
-    name: Approval gate
-    runs-on: ubuntu-latest
-    environment: production-release
-    steps:
-      - name: Approved
-        run: echo "Release approved"
-
   goreleaser:
-    needs: approve
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
## Why

This repository is a release mirror of `BerriAI/litellm//terraform/provider`. The only thing that creates a `v*` tag here is the publish workflow in `BerriAI/project-releaser`, using a token held in that private repo, and that workflow already waits on a `production-release` approval. The source it mirrors was reviewed as a `BerriAI/litellm` PR under gofmt, go vet, build, test, and the endpoint-drift audit before it ever reached this repo.

So the approval gate here re-decided a question that was already settled twice, in a repo nobody has open. The practical cost is latency: a tagged release sits idle until someone thinks to check the Actions tab, which is part of why the registry served a stale provider from May to August.

## What changed

The `approve` job is gone and `goreleaser` runs straight off the tag push.

`GPG_PRIVATE_KEY` and `PASSPHRASE` are repository-level secrets, not scoped to the `production-release` environment (that environment holds zero secrets), so dropping the environment does not change what the signing step can read. The `production-release` environment itself is left in place, unused.

The one approval that remains is in `project-releaser`, where the version and source SHA are actually chosen.

## Companion changes

- `BerriAI/project-releaser#163` stops gating the provider publish on stable releases and on the Docker jobs, so a changelog bump ships within a day instead of waiting up to a week
- `BerriAI/litellm#36467` updates `terraform/provider/RELEASING.md`, which is the upstream source for the `RELEASING.md` in this repo

Merge order does not matter. This change only takes effect on the next tag push.