### PR TITLE
fix(key): don't send empty team_id in UpdateKey

### DIFF
--- a/litellm/client.go
+++ b/litellm/client.go
@@ -125,7 +125,6 @@ func (c *Client) UpdateKey(key *Key) (*Key, error) {
 	// Create a new map with only the fields that can be updated
 	updateData := map[string]interface{}{
 		"key":              key.Key,
-		"team_id":          key.TeamID,
 		"key_alias":        key.KeyAlias,
 		"aliases":          key.Aliases,
 		"permissions":      key.Permissions,
@@ -142,6 +141,11 @@ func (c *Client) UpdateKey(key *Key) (*Key, error) {
 	}
 	if key.ModelTPMLimit != nil {
 		updateData["model_tpm_limit"] = key.ModelTPMLimit
+	}
+	// The proxy rejects an empty team_id with a 500 ("Team object not found"),
+	// so only send it when set.
+	if key.TeamID != "" {
+		updateData["team_id"] = key.TeamID
 	}
 
 	// The proxy rejects an empty-string budget_duration with a 400, so only

--- a/litellm/resource_key_test.go
+++ b/litellm/resource_key_test.go
@@ -360,6 +360,34 @@ func TestResourceKeyUpdateFailureKeepsPriorState(t *testing.T) {
 	}
 }
 
+// LiteLLM rejects an empty team_id with 500 "Team object not found", so a
+// teamless key must never send it.
+func TestUpdateKeyOmitsEmptyTeamID(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"key": "sk-test"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	if _, err := client.UpdateKey(&Key{Key: "sk-test"}); err != nil {
+		t.Fatalf("UpdateKey returned error: %v", err)
+	}
+	if _, present := captured["team_id"]; present {
+		t.Errorf("update payload contains empty team_id: %v", captured["team_id"])
+	}
+
+	if _, err := client.UpdateKey(&Key{Key: "sk-test", TeamID: "team-1"}); err != nil {
+		t.Fatalf("UpdateKey returned error: %v", err)
+	}
+	if captured["team_id"] != "team-1" {
+		t.Errorf("team_id = %v, want team-1", captured["team_id"])
+	}
+}
+
 // /key/info nests the key's fields under "info"; GetKey must unwrap that
 // envelope or reads map nothing back into state.
 func TestGetKeyUnwrapsInfoEnvelope(t *testing.T) {


### PR DESCRIPTION
# PR: fix(key): don't send empty team_id in UpdateKey

Fixes #53

## Problem

`UpdateKey` sends `team_id` unconditionally. For a teamless key, `mapResourceDataToKey` populates it via `d.Get("team_id").(string)`, which is `""` when unset, and LiteLLM rejects that with 500 (`Team object not found for team change validation`). Any update (or import) of a teamless key fails.

(`budget_duration` had the same problem but is already guarded upstream as of `8c8beaf`.)

## Fix

- `litellm/client.go` `UpdateKey`: only set `team_id` in the update payload when non-empty
- `litellm/resource_key.go` `mapResourceDataToKey`: use `d.GetOk("team_id")` instead of `d.Get("team_id")`

## Repro

Save these three files in the same directory.

`docker-compose.yml`:

```yaml
services:
  postgresql:
    image: postgres:16-alpine
    environment:
      POSTGRES_DB: litellm
      POSTGRES_USER: litellm
      POSTGRES_PASSWORD: litellm
    healthcheck:
      test: ["CMD", "pg_isready", "-U", "litellm", "-d", "litellm"]
      interval: 5s
      timeout: 5s
      retries: 10

  litellm:
    image: ghcr.io/berriai/litellm:main-stable
    command: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "1"]
    depends_on:
      postgresql:
        condition: service_healthy
    environment:
      LITELLM_MASTER_KEY: sk-e2e-master-key
      DATABASE_URL: postgresql://litellm:litellm@postgresql:5432/litellm
      STORE_MODEL_IN_DB: "True"
    volumes:
      - ./litellm-config.yaml:/app/config.yaml:ro
    ports:
      - "4000:4000"
    healthcheck:
      # image has no curl/wget, only python3
      test: ["CMD", "python3", "-c", "import urllib.request as u; u.urlopen('http://localhost:4000/health/liveliness', timeout=3)"]
      interval: 10s
      timeout: 5s
      retries: 18
      start_period: 30s
```

`litellm-config.yaml`:

```yaml
model_list: []
general_settings:
  master_key: "sk-e2e-master-key"
  database_connection_pool_limit: 10
  database_url: "postgresql://litellm:litellm@postgresql:5432/litellm"
litellm_settings:
  drop_params: true
```

`repro.py`:

```python
import os
import requests

litellm_url = os.environ["LITELLM_URL"]
master_key = os.environ["MASTER_KEY"]
headers = {"Authorization": f"Bearer {master_key}"}

token = requests.post(f"{litellm_url}/key/generate", headers=headers, json={"max_budget": 50}).json()["token"]

# broken: client.go sends team_id="" for a teamless key -> 500
response = requests.post(f"{litellm_url}/key/update", headers=headers, json={"key": token, "max_budget": 100, "team_id": ""})
print("broken:", response.status_code, response.text)

# fixed: team_id omitted when unset -> 200
response = requests.post(f"{litellm_url}/key/update", headers=headers, json={"key": token, "max_budget": 100})
print("fixed:", response.status_code, response.text)
```

Run:

```bash
docker compose up -d --wait
LITELLM_URL=http://localhost:4000 MASTER_KEY=sk-e2e-master-key python3 repro.py
docker compose down -v
```

`broken:` line is 500 (bug); `fixed:` line is 200 (omitting `team_id` works).
