### PR TITLE
fix(vector-store): generate UUID, parse create response, handle wrapper format

### DIFF
--- a/litellm/resource_vector_store_crud.go
+++ b/litellm/resource_vector_store_crud.go
@@ -1,9 +1,12 @@
 package litellm
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -16,6 +19,12 @@ func resourceLiteLLMVectorStoreCreate(d *schema.ResourceData, m interface{}) err
 	vectorStoreMetadata := d.Get("vector_store_metadata").(map[string]interface{})
 	litellmCredentialName := d.Get("litellm_credential_name").(string)
 	litellmParams := d.Get("litellm_params").(map[string]interface{})
+
+	// Generate a vector_store_id if not provided
+	vectorStoreID := d.Get("vector_store_id").(string)
+	if vectorStoreID == "" {
+		vectorStoreID = uuid.New().String()
+	}
 
 	// Convert metadata to map[string]interface{} for JSON
 	metadataMap := make(map[string]interface{})
@@ -30,6 +39,7 @@ func resourceLiteLLMVectorStoreCreate(d *schema.ResourceData, m interface{}) err
 	}
 
 	vectorStoreRequest := VectorStoreRequest{
+		VectorStoreID:          vectorStoreID,
 		CustomLLMProvider:      customLLMProvider,
 		VectorStoreName:        vectorStoreName,
 		VectorStoreDescription: vectorStoreDescription,
@@ -44,16 +54,45 @@ func resourceLiteLLMVectorStoreCreate(d *schema.ResourceData, m interface{}) err
 	}
 	defer resp.Body.Close()
 
-	err = handleVectorStoreAPIResponse(resp, nil, client)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to create vector store: %w", err)
+		return fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	// Set the resource ID to the vector store name for now
-	// We'll update this after reading the response to get the actual ID
-	d.SetId(vectorStoreName)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("failed to create vector store: Status: %s, Response: %s",
+			resp.Status, client.redactSensitiveData(string(bodyBytes)))
+	}
 
-	return resourceLiteLLMVectorStoreRead(d, m)
+	var createResp struct {
+		VectorStore *VectorStoreResponse `json:"vector_store"`
+		VectorStoreResponse
+	}
+	if err := json.Unmarshal(bodyBytes, &createResp); err != nil {
+		return fmt.Errorf("failed to parse create response: %v", err)
+	}
+
+	respVS := createResp.VectorStoreResponse
+	if createResp.VectorStore != nil {
+		respVS = *createResp.VectorStore
+	}
+
+	if respVS.VectorStoreID != "" {
+		d.SetId(respVS.VectorStoreID)
+	} else {
+		d.SetId(vectorStoreID)
+	}
+
+	d.Set("vector_store_id", respVS.VectorStoreID)
+	d.Set("vector_store_name", respVS.VectorStoreName)
+	d.Set("custom_llm_provider", respVS.CustomLLMProvider)
+	d.Set("vector_store_description", respVS.VectorStoreDescription)
+	d.Set("vector_store_metadata", respVS.VectorStoreMetadata)
+	d.Set("litellm_credential_name", respVS.LiteLLMCredentialName)
+	d.Set("created_at", respVS.CreatedAt)
+	d.Set("updated_at", respVS.UpdatedAt)
+
+	return nil
 }
 
 func resourceLiteLLMVectorStoreRead(d *schema.ResourceData, m interface{}) error {
@@ -76,14 +115,24 @@ func resourceLiteLLMVectorStoreRead(d *schema.ResourceData, m interface{}) error
 		return nil
 	}
 
-	var vectorStoreResp VectorStoreResponse
-	err = handleVectorStoreAPIResponse(resp, &vectorStoreResp, client)
+	// The API wraps the response in {"vector_store": {...}}; fall back to a
+	// flat response for robustness.
+	var wrapper struct {
+		VectorStore *VectorStoreResponse `json:"vector_store"`
+		VectorStoreResponse
+	}
+	err = handleVectorStoreAPIResponse(resp, &wrapper, client)
 	if err != nil {
 		if err.Error() == "vector_store_not_found" {
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("failed to read vector store: %w", err)
+	}
+
+	vectorStoreResp := wrapper.VectorStoreResponse
+	if wrapper.VectorStore != nil {
+		vectorStoreResp = *wrapper.VectorStore
 	}
 
 	// Update the resource ID to the actual vector store ID from the response

--- a/litellm/resource_vector_store_crud_test.go
+++ b/litellm/resource_vector_store_crud_test.go
@@ -53,3 +53,75 @@ func TestVectorStoreReadDoesNotPersistServerLitellmParams(t *testing.T) {
 		t.Fatalf("read did not populate non-sensitive fields")
 	}
 }
+
+// The real API wraps /vector_store/info responses in {"vector_store": {...}}.
+func TestVectorStoreReadUnwrapsResponse(t *testing.T) {
+	inner := VectorStoreResponse{
+		VectorStoreID:     "vs-123",
+		VectorStoreName:   "kb",
+		CustomLLMProvider: "openai",
+	}
+	body, _ := json.Marshal(map[string]interface{}{"vector_store": inner})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMVectorStore().Schema, map[string]interface{}{
+		"vector_store_name":   "kb",
+		"custom_llm_provider": "openai",
+	})
+	d.SetId("vs-123")
+
+	if err := resourceLiteLLMVectorStoreRead(d, client); err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if d.Get("vector_store_id").(string) != "vs-123" {
+		t.Fatalf("wrapped response not unwrapped: vector_store_id = %q", d.Get("vector_store_id"))
+	}
+}
+
+// LiteLLM requires vector_store_id in the create request; the provider must
+// generate one when not configured, and use the real ID from the (wrapped)
+// response as the resource ID, not the store name.
+func TestVectorStoreCreateGeneratesIDAndUsesResponseID(t *testing.T) {
+	var captured VectorStoreRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&captured)
+		resp := map[string]interface{}{
+			"vector_store": VectorStoreResponse{
+				VectorStoreID:     captured.VectorStoreID,
+				VectorStoreName:   captured.VectorStoreName,
+				CustomLLMProvider: captured.CustomLLMProvider,
+			},
+		}
+		body, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMVectorStore().Schema, map[string]interface{}{
+		"vector_store_name":   "kb",
+		"custom_llm_provider": "openai",
+	})
+
+	if err := resourceLiteLLMVectorStoreCreate(d, client); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if captured.VectorStoreID == "" {
+		t.Fatalf("create request sent an empty vector_store_id")
+	}
+	if d.Id() != captured.VectorStoreID {
+		t.Fatalf("resource ID = %q, want the generated vector_store_id %q", d.Id(), captured.VectorStoreID)
+	}
+	if d.Id() == "kb" {
+		t.Fatalf("resource ID was set to the vector store name instead of its ID")
+	}
+}

--- a/litellm/types.go
+++ b/litellm/types.go
@@ -232,7 +232,7 @@ type CredentialResponse struct {
 
 // VectorStoreRequest represents a request to create or update a vector store.
 type VectorStoreRequest struct {
-	VectorStoreID          string                 `json:"vector_store_id,omitempty"`
+	VectorStoreID          string                 `json:"vector_store_id"`
 	CustomLLMProvider      string                 `json:"custom_llm_provider"`
 	VectorStoreName        string                 `json:"vector_store_name"`
 	VectorStoreDescription string                 `json:"vector_store_description,omitempty"`


### PR DESCRIPTION
# PR: fix(vector-store): generate UUID, parse create response, handle wrapper format

## Problem

Three bugs prevent vector store creation from working:

1. `VectorStoreRequest` omits `vector_store_id` when empty (`omitempty` tag). API returns 500 (`{"detail":"400: vector_store_id and custom_llm_provider are required"}`).
2. Create response is discarded (`nil` parser). Resource ID set to store name instead of actual UUID. All subsequent Read/Update/Delete fail.
3. Read function unmarshals `/vector_store/info` response directly into `VectorStoreResponse`, but API wraps it in `{"vector_store": {...}}`. All fields stay zero-valued.

## Fix

- `types.go`: Remove `omitempty` from `VectorStoreID` JSON tag
- `resource_vector_store_crud.go` create: Generate UUID if empty, parse response body, handle both wrapped and flat formats
- `resource_vector_store_crud.go` read: Unwrap `{"vector_store": {...}}` response

## Files

- `litellm/types.go` — JSON tag fix
- `litellm/resource_vector_store_crud.go` — UUID gen, response parse, wrapper handling

## Repro

Save these three files in the same directory.

`docker-compose.yml`:

```yaml
services:
  postgresql:
    image: postgres:16-alpine
    environment:
      POSTGRES_DB: litellm
      POSTGRES_USER: litellm
      POSTGRES_PASSWORD: litellm
    healthcheck:
      test: ["CMD", "pg_isready", "-U", "litellm", "-d", "litellm"]
      interval: 5s
      timeout: 5s
      retries: 10

  litellm:
    image: ghcr.io/berriai/litellm:main-stable
    command: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "1"]
    depends_on:
      postgresql:
        condition: service_healthy
    environment:
      LITELLM_MASTER_KEY: sk-e2e-master-key
      DATABASE_URL: postgresql://litellm:litellm@postgresql:5432/litellm
      STORE_MODEL_IN_DB: "True"
    volumes:
      - ./litellm-config.yaml:/app/config.yaml:ro
    ports:
      - "4000:4000"
    healthcheck:
      # image has no curl/wget, only python3
      test: ["CMD", "python3", "-c", "import urllib.request as u; u.urlopen('http://localhost:4000/health/liveliness', timeout=3)"]
      interval: 10s
      timeout: 5s
      retries: 18
      start_period: 30s
```

`litellm-config.yaml`:

```yaml
model_list: []
general_settings:
  master_key: "sk-e2e-master-key"
  database_connection_pool_limit: 10
  database_url: "postgresql://litellm:litellm@postgresql:5432/litellm"
litellm_settings:
  drop_params: true
```

`repro.py`:

```python
import os
import uuid
import requests

litellm_url = os.environ["LITELLM_URL"]
master_key = os.environ["MASTER_KEY"]
headers = {"Authorization": f"Bearer {master_key}"}

# broken: vector_store_id omitted -> rejected
response = requests.post(f"{litellm_url}/vector_store/new", headers=headers, json={"custom_llm_provider": "openai", "vector_store_name": "test"})
print("broken:", response.status_code, response.text)

# fixed: vector_store_id set -> succeeds, but /info wraps the result
vector_store_id = str(uuid.uuid4())
requests.post(f"{litellm_url}/vector_store/new", headers=headers, json={"vector_store_id": vector_store_id, "custom_llm_provider": "openai", "vector_store_name": "test"})
response = requests.post(f"{litellm_url}/vector_store/info", headers=headers, json={"vector_store_id": vector_store_id})
print("fixed (wrapped):", response.status_code, response.text)
```

Run:

```bash
docker compose up -d --wait
LITELLM_URL=http://localhost:4000 MASTER_KEY=sk-e2e-master-key python3 repro.py
docker compose down -v
```

`broken:` line is 500 (bug); `fixed (wrapped):` line is 200 but the body is wrapped in `{"vector_store": {...}}`, confirming bug #3.
